### PR TITLE
extend configuration options to exclude files or folders from being copied to the localization folders.

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,17 @@ languages: ["sv", "en", "de", "fr"]
 
 The first language in the array will be the default language, English, German and French will be added in to separate subfolders.
 
+To avoid redundancy, it is possible to exclude files and folders from beeing copied to the localization folders. 
+
+```yaml
+exclude_from_localizations: [javascript", "images", "css"]
+```
+In code these specific files shoule be referenced via `baseurl_root`. E.g.
+
+```
+<link rel="stylesheet" href="{{ "/css/bootstrap.css" | prepend: site.baseurl_root }}"/>
+```
+
 ###i18n
 Create this folder structure in your Jekyll project as an example:
 

--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ The first language in the array will be the default language, English, German an
 To avoid redundancy, it is possible to exclude files and folders from beeing copied to the localization folders. 
 
 ```yaml
-exclude_from_localizations: [javascript", "images", "css"]
+exclude_from_localizations: ["javascript", "images", "css"]
 ```
 In code these specific files shoule be referenced via `baseurl_root`. E.g.
 

--- a/lib/jekyll/multiple/languages/plugin.rb
+++ b/lib/jekyll/multiple/languages/plugin.rb
@@ -18,6 +18,7 @@ module Jekyll
       config['baseurl_root'] = self.config['baseurl']
       baseurl_org = self.config['baseurl']
       languages = self.config['languages']
+      exclude_org = self.config['exclude']
       dest_org = self.dest
 
       #Loop
@@ -31,12 +32,16 @@ module Jekyll
         @dest = @dest + "/" + lang
         self.config['baseurl'] = self.config['baseurl'] + "/" + lang
         self.config['lang'] = lang
+        # exclude folders or files from beeing copied to all the language folders
+        exclude_from_localizations = self.config['exclude_from_localizations'] || []
+        self.config['exclude'] = exclude_org.concat(exclude_from_localizations)
         puts "Building site for language: \"#{self.config['lang']}\" to: #{self.dest}"
         process_org
 
         #Reset variables for next language
         @dest = dest_org
         self.config['baseurl'] = baseurl_org
+        self.config['exclude'] = exclude_org
       end
       Jekyll.setlangs({})
       puts 'Build complete'


### PR DESCRIPTION
Extends Jekyll's `exclude` option to exclude folders/files from the language folders