### PR TITLE
Fixed permalink in example _config.yml.

### DIFF
--- a/example/_config.yml
+++ b/example/_config.yml
@@ -3,5 +3,6 @@ markdown: redcarpet
 pygments: true
 
 baseurl: ""
+permalink: /:title/
 
 languages: ["it", "en", "es"]


### PR DESCRIPTION
* Added permalink /:title/ to _config.yml.

Without the parameter changing the post language was not working, 'cause
page.url added the original post language to the URL (the two letter
code language is a category that goes to the URL).

The result was that when choosing Spanish from English for example, the
URL was /en/_i18n/es/...