### PR TITLE
Fix README

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,7 +171,7 @@ titles:
 This plugin gives you the variables
 
 ```liquid
-{{ page.lang }}
+{{ site.lang }}
 
 and
 


### PR DESCRIPTION
It's `site.lang`, right?