### PR TITLE
Add LocalizeLinks and custom permalinks for each lang

### DIFF
--- a/lib/jekyll/multiple/languages/plugin.rb
+++ b/lib/jekyll/multiple/languages/plugin.rb
@@ -67,11 +67,7 @@ module Jekyll
         File.join(@dir, data['permalink'])
       else
         # Look if there's a permalink overwrite specified for this lang
-        if data['permalink_'+site.config['lang']]
-          data['permalink_'+site.config['lang']]
-        else
-          data['permalink']
-        end
+        data['permalink_'+site.config['lang']] || data['permalink']
       end
     end
   end
@@ -162,10 +158,11 @@ module Jekyll
       end
       key = key.split
       namespace = key[0]
-      lang = (key[1].nil? ? context.registers[:site].config['lang'] : key[1])
+      lang = key[1] || context.registers[:site].config['lang']
       default_lang = context.registers[:site].config['default_lang']
       baseurl = context.registers[:site].baseurl
       pages = context.registers[:site].pages
+      url = "";
 
       if default_lang != lang
         baseurl = baseurl + "/" + lang
@@ -175,11 +172,7 @@ module Jekyll
         unless p['namespace'].nil?
           page_namespace = p['namespace']
           if namespace == page_namespace
-            if p['permalink_'+lang]
-              permalink = p['permalink_'+lang]
-            else
-              permalink = p['permalink']
-            end
+            permalink = p['permalink_'+lang] || p['permalink']
             url = baseurl + permalink
           end
         end

--- a/lib/jekyll/multiple/languages/plugin.rb
+++ b/lib/jekyll/multiple/languages/plugin.rb
@@ -60,6 +60,22 @@ module Jekyll
     end
   end
 
+  class Page
+    def permalink
+      return nil if data.nil? || data['permalink'].nil?
+      if site.config['relative_permalinks']
+        File.join(@dir, data['permalink'])
+      else
+        # Look if there's a permalink overwrite specified for this lang
+        if data['permalink_'+site.config['lang']]
+          data['permalink_'+site.config['lang']]
+        else
+          data['permalink']
+        end
+      end
+    end
+  end
+
   class LocalizeTag < Liquid::Tag
 
     def initialize(tag_name, key, tokens)
@@ -130,6 +146,47 @@ module Jekyll
       end
     end
   end
+
+  class LocalizeLink < Liquid::Tag
+
+    def initialize(tag_name, key, tokens)
+      super
+      @key = key
+    end
+
+    def render(context)
+      if "#{context[@key]}" != "" #Check for page variable
+        key = "#{context[@key]}"
+      else
+        key = @key
+      end
+      key = key.split
+      namespace = key[0]
+      lang = (key[1].nil? ? context.registers[:site].config['lang'] : key[1])
+      default_lang = context.registers[:site].config['default_lang']
+      baseurl = context.registers[:site].baseurl
+      pages = context.registers[:site].pages
+
+      if default_lang != lang
+        baseurl = baseurl + "/" + lang
+      end
+
+      for p in pages
+        unless p['namespace'].nil?
+          page_namespace = p['namespace']
+          if namespace == page_namespace
+            if p['permalink_'+lang]
+              permalink = p['permalink_'+lang]
+            else
+              permalink = p['permalink']
+            end
+            url = baseurl + permalink
+          end
+        end
+      end
+      url
+    end
+  end
 end
 
 unless Hash.method_defined? :access
@@ -153,3 +210,5 @@ Liquid::Template.register_tag('t', Jekyll::LocalizeTag)
 Liquid::Template.register_tag('translate', Jekyll::LocalizeTag)
 Liquid::Template.register_tag('tf', Jekyll::Tags::LocalizeInclude)
 Liquid::Template.register_tag('translate_file', Jekyll::Tags::LocalizeInclude)
+Liquid::Template.register_tag('tl', Jekyll::LocalizeLink)
+Liquid::Template.register_tag('translate_link', Jekyll::LocalizeLink)


### PR DESCRIPTION
Hi folks,

Currently, the plugin returns `/my_page` and `/lang/my_page` but I needed to produce different urls depending on the language, like `/team` and `/fr/equipe`. I added the functionality to do so by adding a variable in the front matter like this :
```
---
permalink: /team/
permalink_fr: /equipe/
---
```
When french (fr) pages (or any languages) will be generated, the site will look for `permalink_fr` and use it if it exists, otherwise it will fallback to the default `permalink`. In this case, it would generate `/team/index.html` and `/fr/equipe/index.html`.

I also created a new function `translate_links`, returning the correct link for a specified lang or, if not specified, for the current lang.

To use that, pages need to have a unique namespace variable. This might not be the best solution, but as my first time with Ruby and Jekyll, this is what I came up with.
```
---
layout:         default
namespace:     team
permalink:      /team/
permalink_fr:   /equipe/
---

<a href="{% tl team %}">This link will return /team if we are in the english version of the website and /fr/equipe if it's the french version</a>

<a href="{% tl team fr %}">This link will always return /fr/equipe</a>
```

You can also create an easy lang switcher like so :
```
{% if site.lang == "fr" %}
{% capture link %}{{page.namespace}} en{% endcapture %}
    <a href="{% tl {{ link }} %}">En</a>
{% else if site.lang == "en" %}
{% capture link %}{{page.namespace}} fr{% endcapture %}
    <a href="{% tl {{ link }} %}">Fr</a>
{% endif %}
```

Waiting for your comments so we can make this live, as this would definitely be a nice feature to have.